### PR TITLE
Gh 129

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		classpath 'io.spring.gradle:spring-build-conventions:0.0.25.RELEASE'
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
 		classpath 'io.spring.javaformat:spring-javaformat-gradle-plugin:0.0.6'
-		classpath 'io.spring.nohttp:nohttp-gradle:0.0.1.RELEASE'
+		classpath 'io.spring.nohttp:nohttp-gradle:0.0.2.BUILD-SNAPSHOT'
 	}
 	repositories {
 		maven { url 'https://repo.spring.io/libs-snapshot' }

--- a/fail.txt
+++ b/fail.txt
@@ -1,0 +1,1 @@
+http://fail.com


### PR DESCRIPTION
This updates the build to use the latest SNAPSHOT which ensures that `check` depends on `checkstyleNohttp`. Make sure you use `--refresh-dependencies` to get the latest SNAPSHOT.